### PR TITLE
add `trim` function and fix testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,18 @@ VERSION ?= DEV
 all: clean build
 
 test-lite:
-	@go test -cover ./...
+	@go test ./... -coverprofile lite.out
 
 test-sprig:
-	@go test -tags sprig -cover ./...
+	@go test -tags sprig ./... -coverprofile sprig.out
 
 test: test-lite test-sprig
+
+cover: test
+cover:
+	@cp lite.out combo.out
+	@cat sprig.out | grep -v ^"mode: set" >> combo.out
+	@go tool cover -func=combo.out
 
 clean:
 	@go clean

--- a/README.md
+++ b/README.md
@@ -77,3 +77,13 @@ envFile "MYENV"
 ```
 
 will read `MYENV` from environment and return that value if exists. If it does not, it will read `MYENV_FILE` and it that does exist it will return the **contents** of the file in that variable.
+
+### trim
+
+The `trim` function removes space from either side of a string:
+
+```
+trim "   hello    "
+```
+
+The above produces `hello`

--- a/funcmap/funcmap_common.go
+++ b/funcmap/funcmap_common.go
@@ -29,3 +29,7 @@ func CommonFuncMap() template.FuncMap {
 		"envFile": GetenvFile,
 	}
 }
+
+func NewTemplateWithAllFuncMaps(name string) *template.Template {
+	return template.New(name).Funcs(CommonFuncMap()).Funcs(FuncMap())
+}

--- a/funcmap/funcmap_nosprig.go
+++ b/funcmap/funcmap_nosprig.go
@@ -5,11 +5,13 @@ package funcmap
 
 import (
 	"os"
+	"strings"
 	"text/template"
 )
 
 func FuncMap() template.FuncMap {
 	return template.FuncMap{
-		"env": os.Getenv,
+		"env":  os.Getenv,
+		"trim": strings.TrimSpace,
 	}
 }

--- a/funcmap/funcmap_sprig_test.go
+++ b/funcmap/funcmap_sprig_test.go
@@ -8,17 +8,12 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-	"text/template"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func newTemplate() *template.Template {
-	return template.New("test").Funcs(CommonFuncMap()).Funcs(FuncMap())
-}
-
 func TestEnvNotSet(t *testing.T) {
-	template, err := newTemplate().Parse(`Hello {{ env "UNKNOWN" }}`)
+	template, err := NewTemplateWithAllFuncMaps("test").Parse(`Hello {{ env "UNKNOWN" }}`)
 	assert.Nil(t, err)
 	var buf bytes.Buffer
 	err = template.Execute(&buf, nil)
@@ -28,7 +23,7 @@ func TestEnvNotSet(t *testing.T) {
 
 func TestEnv(t *testing.T) {
 	os.Setenv("UNKNOWN", "World")
-	template, err := newTemplate().Parse(`Hello {{ env "UNKNOWN" }}`)
+	template, err := NewTemplateWithAllFuncMaps("test").Parse(`Hello {{ env "UNKNOWN" }}`)
 	assert.Nil(t, err)
 	var buf bytes.Buffer
 	err = template.Execute(&buf, nil)
@@ -37,7 +32,7 @@ func TestEnv(t *testing.T) {
 }
 
 func TestUpper(t *testing.T) {
-	template, err := newTemplate().Parse(`Hello {{ upper "Gopher" }}`)
+	template, err := NewTemplateWithAllFuncMaps("test").Parse(`Hello {{ upper "Gopher" }}`)
 	assert.Nil(t, err)
 	var buf bytes.Buffer
 	err = template.Execute(&buf, nil)
@@ -53,7 +48,7 @@ func TestEnvFile(t *testing.T) {
 	os.WriteFile(file.Name(), []byte("There"), 0644)
 	os.Setenv("UNKNOWN", "")
 	os.Setenv("UNKNOWN_FILE", file.Name())
-	template, err := newTemplate().Parse(`Hello {{ envFile "UNKNOWN" }}`)
+	template, err := NewTemplateWithAllFuncMaps("test").Parse(`Hello {{ envFile "UNKNOWN" }}`)
 	assert.Nil(t, err)
 	var buf bytes.Buffer
 	err = template.Execute(&buf, nil)

--- a/main.go
+++ b/main.go
@@ -40,10 +40,10 @@ func main() {
 	if flag.Arg(0) == "-" {
 		bytes, err := ioutil.ReadAll(os.Stdin)
 		if err == nil {
-			t, err = template.New(path.Base(flag.Arg(0))).Funcs(funcmap.FuncMap()).Parse(string(bytes))
+			t, err = funcmap.NewTemplateWithAllFuncMaps(path.Base(flag.Arg(0))).Parse(string(bytes))
 		}
 	} else {
-		t, err = template.New(path.Base(flag.Arg(0))).Funcs(funcmap.FuncMap()).ParseFiles(flag.Arg(0))
+		t, err = funcmap.NewTemplateWithAllFuncMaps("stdin").ParseFiles(flag.Arg(0))
 	}
 
 	if err != nil {


### PR DESCRIPTION
Trimming is useful with `envFile` as different file editors will always add ending newline

Refactored tests to make sure it uses the same combo funcmap as main.go does (0.1.7 release missed `CommonFuncMap`)